### PR TITLE
Add key usages to the x509 csr.

### DIFF
--- a/pkg/cfg/config.go
+++ b/pkg/cfg/config.go
@@ -24,19 +24,19 @@ import (
 
 // Config holds parameters that are used during runtime.
 type Config struct {
-	CSRName            string
-	EmptyDirLocation   string
-	Signer             string
-	CommonName         string
-	EmailAddress       string
-	PodIP              string
-	KeyName            string
-	CertName           string
-	DNSNames           []string
-	SignatureAlgorithm string
-	NewPrivateKey      string
-	RegisterApiserver  bool
-	AppName            string
+	CSRName             string
+	EmptyDirLocation    string
+	Signer              string
+	CommonName          string
+	EmailAddress        string
+	PodIP               string
+	KeyName             string
+	CertName            string
+	DNSNames            []string
+	SignatureAlgorithm  string
+	PrivateKeyAlgorithm string
+	RegisterApiserver   bool
+	AppName             string
 }
 
 // GetEnvOrDie convenience method for initializing env.
@@ -55,17 +55,17 @@ func GetConfigOrDie() *Config {
 		log.Fatal("environment variable DNS_NAMES cannot be empty")
 	}
 	return &Config{
-		CSRName:            fmt.Sprintf("%s:%s", GetEnvOrDie("POD_NAMESPACE"), GetEnvOrDie("POD_NAME")),
-		SignatureAlgorithm: os.Getenv("SIGNATURE_ALGORITHM"),
-		Signer:             GetEnvOrDie("SIGNER"),
-		CommonName:         GetEnvOrDie("COMMON_NAME"),
-		EmailAddress:       os.Getenv("EMAIL_ADDRESS"),
-		EmptyDirLocation:   GetEnvOrDie("CERTIFICATE_PATH"),
-		KeyName:            GetEnvOrDie("KEY_NAME"),
-		CertName:           GetEnvOrDie("CERT_NAME"),
-		PodIP:              GetEnvOrDie("POD_IP"),
-		AppName:            GetEnvOrDie("APP_NAME"),
-		NewPrivateKey:      os.Getenv("KEY_ALGORITHM"),
-		DNSNames:           dnsNames,
+		CSRName:             fmt.Sprintf("%s:%s", GetEnvOrDie("POD_NAMESPACE"), GetEnvOrDie("POD_NAME")),
+		SignatureAlgorithm:  os.Getenv("SIGNATURE_ALGORITHM"),
+		Signer:              GetEnvOrDie("SIGNER"),
+		CommonName:          GetEnvOrDie("COMMON_NAME"),
+		EmailAddress:        os.Getenv("EMAIL_ADDRESS"),
+		EmptyDirLocation:    GetEnvOrDie("CERTIFICATE_PATH"),
+		KeyName:             GetEnvOrDie("KEY_NAME"),
+		CertName:            GetEnvOrDie("CERT_NAME"),
+		PodIP:               GetEnvOrDie("POD_IP"),
+		AppName:             GetEnvOrDie("APP_NAME"),
+		PrivateKeyAlgorithm: os.Getenv("KEY_ALGORITHM"),
+		DNSNames:            dnsNames,
 	}
 }

--- a/pkg/k8s/certificate.go
+++ b/pkg/k8s/certificate.go
@@ -92,7 +92,7 @@ func SubmitCSR(ctx context.Context, config *cfg.Config, restClient *RestClient, 
 		Spec: v1beta1.CertificateSigningRequestSpec{
 			Request:    x509CSR.CSR,
 			SignerName: &config.Signer,
-			Usages:     []v1beta1.KeyUsage{v1beta1.UsageServerAuth, v1beta1.UsageDigitalSignature, v1beta1.UsageKeyAgreement},
+			Usages:     []v1beta1.KeyUsage{v1beta1.UsageServerAuth, v1beta1.UsageClientAuth, v1beta1.UsageDigitalSignature, v1beta1.UsageKeyAgreement},
 		},
 	}
 

--- a/pkg/k8s/certificate_test.go
+++ b/pkg/k8s/certificate_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Test Certificates", func() {
 			Expect(csr.Name).To(Equal(csrName))
 			Expect(csr.Spec.Request).To(Equal(csrPem))
 			Expect(*csr.Spec.SignerName).To(Equal(signer))
-			Expect(csr.Spec.Usages).To(ConsistOf(v1beta1.UsageServerAuth, v1beta1.UsageDigitalSignature, v1beta1.UsageKeyAgreement))
+			Expect(csr.Spec.Usages).To(ConsistOf(v1beta1.UsageServerAuth, v1beta1.UsageClientAuth, v1beta1.UsageDigitalSignature, v1beta1.UsageKeyAgreement))
 		})
 	})
 })

--- a/signer/main.go
+++ b/signer/main.go
@@ -133,8 +133,8 @@ func main() {
 				NotBefore:             time.Now(),
 				NotAfter:              time.Now().Add(10E4 * time.Hour),
 				// see http://golang.org/pkg/crypto/x509/#KeyUsage
-				KeyUsage:       x509.KeyUsageDigitalSignature,
-				ExtKeyUsage:    []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+				KeyUsage:       x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+				ExtKeyUsage:    []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 				DNSNames:       cr.DNSNames,
 				IPAddresses:    cr.IPAddresses,
 				EmailAddresses: cr.EmailAddresses,


### PR DESCRIPTION
Previously key usages were only specified in the k8s csr. We added them to the x509 csr too now.