### PR TITLE
Write the CA cert to a file if this information is present in the environment variables

### DIFF
--- a/pkg/cfg/config.go
+++ b/pkg/cfg/config.go
@@ -66,7 +66,7 @@ func GetConfigOrDie() *Config {
 		var err error
 		caCert, err = base64.URLEncoding.DecodeString(b64CACert)
 		if err != nil {
-			log.Fatalf("Error while decoding CA Cert: %w", err)
+			log.Fatalf("Error while decoding CA Cert: %v", err)
 		}
 		caCertName = GetEnvOrDie("CA_CERT_NAME")
 	}

--- a/pkg/k8s/certificate.go
+++ b/pkg/k8s/certificate.go
@@ -95,7 +95,7 @@ func watchCSRUsingCertV1(watcher *watch.Interface, cfg *cfg.Config, x509CSR *tls
 				}
 			}
 			if approved {
-				return writeCertificateToFile(cfg, chcsr.Status.Certificate, x509CSR)
+				return WriteCertificateToFile(cfg, chcsr.Status.Certificate, x509CSR)
 			}
 		}
 	}
@@ -124,14 +124,15 @@ func watchCSRUsingCertV1beta1(watcher *watch.Interface, cfg *cfg.Config, x509CSR
 				}
 			}
 			if approved {
-				return writeCertificateToFile(cfg, chcsr.Status.Certificate, x509CSR)
+				return WriteCertificateToFile(cfg, chcsr.Status.Certificate, x509CSR)
 			}
 		}
 	}
 	return nil
 }
 
-func writeCertificateToFile(cfg *cfg.Config, cert []byte, x509CSR *tls.X509CSR) error {
+// WriteCertificateToFile writes TLS key, cert and cacert to the mount location specified in the config parameter.
+func WriteCertificateToFile(cfg *cfg.Config, cert []byte, x509CSR *tls.X509CSR) error {
 	log.Infof("the CSR has been signed and approved, writing to certificate location: %v", cfg.EmptyDirLocation)
 
 	// Give other users read permission to this file.
@@ -147,7 +148,7 @@ func writeCertificateToFile(cfg *cfg.Config, cert []byte, x509CSR *tls.X509CSR) 
 	}
 
 	// Write the CA Cert to a file if it was provided.
-	if len(cfg.CACertPEM) > 0 {
+	if len(cfg.CACertPEM) > 0 && len(cfg.CACertName) > 0 {
 		err = ioutil.WriteFile(path.Join(cfg.EmptyDirLocation, cfg.CACertName), cfg.CACertPEM, os.FileMode(0744))
 		if err != nil {
 			return fmt.Errorf("error while writing to file: %w", err)

--- a/pkg/k8s/certificate.go
+++ b/pkg/k8s/certificate.go
@@ -145,6 +145,14 @@ func writeCertificateToFile(cfg *cfg.Config, cert []byte, x509CSR *tls.X509CSR) 
 	if err != nil {
 		return fmt.Errorf("error while writing to file: %w", err)
 	}
+
+	// Write the CA Cert to a file if it was provided.
+	if len(cfg.CACertPEM) > 0 {
+		err = ioutil.WriteFile(path.Join(cfg.EmptyDirLocation, cfg.CACertName), cfg.CACertPEM, os.FileMode(0744))
+		if err != nil {
+			return fmt.Errorf("error while writing to file: %w", err)
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
Some pods not only need to present a cert, but also trust the ca for their TLS traffic.