### PR TITLE
Automated cherry pick of #42: Build with go 1.17.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Tigera, Inc. All rights reserved.
 
 PACKAGE_NAME    ?= github.com/tigera/key-cert-provisioner
-GO_BUILD_VER    ?= v0.65.1
+GO_BUILD_VER    ?= v0.65.2
 GIT_USE_SSH      = true
 
 ORGANIZATION=tigera


### PR DESCRIPTION
Cherry pick of #42 on release-v1.1.

#42: Build with go 1.17.9