### PR TITLE
Automated cherry pick of #47: Bump go-build to pick up release process fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Tigera, Inc. All rights reserved.
 
 PACKAGE_NAME    ?= github.com/tigera/key-cert-provisioner
-GO_BUILD_VER    ?= v0.65.2
+GO_BUILD_VER    ?= v0.65.3
 GIT_USE_SSH      = true
 
 ORGANIZATION=tigera


### PR DESCRIPTION
Cherry pick of #47 on release-v1.1.

#47: Bump go-build to pick up release process fixes