### PR TITLE
[EV-2594] Upgrade go to v1.18.8 (go-build v0.76). Set UBI tag to latest

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6 AS ubi
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS ubi
 
 FROM scratch
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Tigera, Inc. All rights reserved.
 
 PACKAGE_NAME    ?= github.com/tigera/key-cert-provisioner
-GO_BUILD_VER    ?= v0.75
+GO_BUILD_VER    ?= v0.76
 GIT_USE_SSH      = true
 
 ORGANIZATION=tigera
@@ -86,7 +86,7 @@ clean:
 image: tigera/key-cert-provisioner
 tigera/key-cert-provisioner: tigera/key-cert-provisioner-$(ARCH)
 tigera/key-cert-provisioner-$(ARCH): build
-	docker build --pull -t tigera/key-cert-provisioner:latest-$(ARCH) --file ./Dockerfile.$(ARCH) .
+	docker buildx build --pull -t tigera/key-cert-provisioner:latest-$(ARCH) --file ./Dockerfile.$(ARCH) .
 ifeq ($(ARCH),amd64)
 	docker tag tigera/key-cert-provisioner:latest-$(ARCH) tigera/key-cert-provisioner:latest
 endif


### PR DESCRIPTION
* Upgrade go to `v1.18.8`, go-build `v0.76`
* Set UBI dockerfile tag to `latest`