### PR TITLE
[EV-2957] Upgrade go-build to v0.78

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Tigera, Inc. All rights reserved.
 
 PACKAGE_NAME    ?= github.com/tigera/key-cert-provisioner
-GO_BUILD_VER    ?= v0.76
+GO_BUILD_VER    ?= v0.78
 GIT_USE_SSH      = true
 
 ORGANIZATION=tigera


### PR DESCRIPTION
- Upgrade `go-build` to `v0.78`, `go v1.18.9`