### PR TITLE
Avoid csr name clash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ define build_static_cgo_boring_binary
         $(GO_BUILD_IMAGE):$(GO_BUILD_VER) \
         sh -c '$(GIT_CONFIG_SSH) \
             GOEXPERIMENT=boringcrypto go build -o $(2)  \
-            -tags fipsstrict,osusergo,netgo$(if $(BUILD_TAGS),$(comma)$(BUILD_TAGS)) -v -buildvcs=false \
+            -tags fipsstrict,osusergo,netgo$(if $(BUILD_TAGS),$(comma)$(BUILD_TAGS)) -v \
             -ldflags "$(LDFLAGS) -linkmode external -extldflags -static -s -w" \
             $(1) \
             && strings $(2) | grep '_Cfunc__goboringcrypto_' 1> /dev/null'

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ Makefile.common.$(MAKE_BRANCH):
 	rm -f Makefile.common.*
 	curl --fail $(MAKE_REPO)/Makefile.common -o "$@"
 
+GOFLAGS = -buildvcs=false
 include Makefile.common
 
 # Build a static binary with boring crypto support.

--- a/pkg/k8s/certificate.go
+++ b/pkg/k8s/certificate.go
@@ -19,61 +19,28 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"strconv"
-	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/tigera/key-cert-provisioner/pkg/cfg"
 	"github.com/tigera/key-cert-provisioner/pkg/tls"
-
 	certV1 "k8s.io/api/certificates/v1"
-	certV1beta1 "k8s.io/api/certificates/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/kubernetes"
 )
-
-type versionInfo struct {
-	Major int
-	Minor int
-}
 
 // WatchCSR Watches the CSR resource for updates and writes results to the certificate location (which should be mounted as an emptyDir)
 func WatchCSR(ctx context.Context, restClient *RestClient, cfg *cfg.Config, x509CSR *tls.X509CSR) error {
-	version, err := GetKubernetesVersion(restClient.Clientset)
-	if err != nil {
-		return err
-	}
-
-	watcher, err := createCSRWatcher(ctx, restClient, version)
+	watcher, err := restClient.Clientset.CertificatesV1().CertificateSigningRequests().Watch(ctx, metav1.ListOptions{})
 	if err != nil {
 		return fmt.Errorf("unable to watch certificate requests: %w", err)
 	}
 	log.Infof("watching CSR until it has been signed and approved: %v", cfg.CSRName)
-	return watchCSRBasedOnKubernetesVersion(watcher, cfg, x509CSR, version)
+	return watchCSR(&watcher, cfg, x509CSR)
 }
 
-func createCSRWatcher(ctx context.Context, restClient *RestClient, version *versionInfo) (*watch.Interface, error) {
-	var watcher watch.Interface
-	var err error
-	if version.Major > 1 || version.Minor >= 19 {
-		watcher, err = restClient.Clientset.CertificatesV1().CertificateSigningRequests().Watch(ctx, metav1.ListOptions{})
-	} else {
-		watcher, err = restClient.Clientset.CertificatesV1beta1().CertificateSigningRequests().Watch(ctx, metav1.ListOptions{})
-	}
-	return &watcher, err
-}
-
-func watchCSRBasedOnKubernetesVersion(watcher *watch.Interface, cfg *cfg.Config, x509CSR *tls.X509CSR, version *versionInfo) error {
-	if version.Major > 1 || version.Minor >= 19 {
-		return watchCSRUsingCertV1(watcher, cfg, x509CSR)
-	}
-	return watchCSRUsingCertV1beta1(watcher, cfg, x509CSR)
-}
-
-func watchCSRUsingCertV1(watcher *watch.Interface, cfg *cfg.Config, x509CSR *tls.X509CSR) error {
+func watchCSR(watcher *watch.Interface, cfg *cfg.Config, x509CSR *tls.X509CSR) error {
 	for event := range (*watcher).ResultChan() {
 		chcsr, ok := event.Object.(*certV1.CertificateSigningRequest)
 		if !ok {
@@ -90,35 +57,6 @@ func watchCSRUsingCertV1(watcher *watch.Interface, cfg *cfg.Config, x509CSR *tls
 					return fmt.Errorf("CSR was denied for this pod. CSR name: %s", cfg.CSRName)
 				}
 				if c.Type == certV1.CertificateFailed && c.Status == v1.ConditionTrue {
-					return fmt.Errorf("CSR failed for this pod. CSR name: %s", cfg.CSRName)
-				}
-			}
-			if approved {
-				return WriteCertificateToFile(cfg, chcsr.Status.Certificate, x509CSR)
-			}
-		}
-	}
-	return nil
-}
-
-func watchCSRUsingCertV1beta1(watcher *watch.Interface, cfg *cfg.Config, x509CSR *tls.X509CSR) error {
-	for event := range (*watcher).ResultChan() {
-		chcsr, ok := event.Object.(*certV1beta1.CertificateSigningRequest)
-		if !ok {
-			return fmt.Errorf("unexpected type in CertificateSigningRequest channel: %o", event.Object)
-		}
-		if chcsr.Name == cfg.CSRName && chcsr.Status.Conditions != nil && len(chcsr.Status.Certificate) > 0 {
-			approved := false
-			for _, c := range chcsr.Status.Conditions {
-				//status unset should be treated as true for backwards compatibility.
-				if c.Type == certV1beta1.CertificateApproved && (c.Status == v1.ConditionTrue || c.Status == "") {
-					approved = true
-					break
-				}
-				if c.Type == certV1beta1.CertificateDenied && c.Status == v1.ConditionTrue {
-					return fmt.Errorf("CSR was denied for this pod. CSR name: %s", cfg.CSRName)
-				}
-				if c.Type == certV1beta1.CertificateFailed && c.Status == v1.ConditionTrue {
 					return fmt.Errorf("CSR failed for this pod. CSR name: %s", cfg.CSRName)
 				}
 			}
@@ -158,22 +96,6 @@ func WriteCertificateToFile(cfg *cfg.Config, cert []byte, x509CSR *tls.X509CSR) 
 
 // SubmitCSR Submits a CSR in order to obtain a signed certificate for this pod.
 func SubmitCSR(ctx context.Context, config *cfg.Config, restClient *RestClient, x509CSR *tls.X509CSR) error {
-	version, err := GetKubernetesVersion(restClient.Clientset)
-	if err != nil {
-		return err
-	}
-
-	return submitCSRBasedOnKubernetesVersion(ctx, config, restClient, x509CSR, version)
-}
-
-func submitCSRBasedOnKubernetesVersion(ctx context.Context, config *cfg.Config, restClient *RestClient, x509CSR *tls.X509CSR, version *versionInfo) error {
-	if version.Major > 1 || version.Minor >= 19 {
-		return submitCSRUsingCertV1(ctx, config, restClient, x509CSR)
-	}
-	return submitCSRUsingCertV1beta1(ctx, config, restClient, x509CSR)
-}
-
-func submitCSRUsingCertV1(ctx context.Context, config *cfg.Config, restClient *RestClient, x509CSR *tls.X509CSR) error {
 	cli := restClient.Clientset.CertificatesV1().CertificateSigningRequests()
 	csr := &certV1.CertificateSigningRequest{
 		TypeMeta: metav1.TypeMeta{Kind: "CertificateSigningRequest", APIVersion: "certificates.k8s.io/v1"},
@@ -207,63 +129,4 @@ func submitCSRUsingCertV1(ctx context.Context, config *cfg.Config, restClient *R
 
 	log.Infof("created CSR: %v", created)
 	return nil
-}
-
-func submitCSRUsingCertV1beta1(ctx context.Context, config *cfg.Config, restClient *RestClient, x509CSR *tls.X509CSR) error {
-	cli := restClient.Clientset.CertificatesV1beta1().CertificateSigningRequests()
-	csr := &certV1beta1.CertificateSigningRequest{
-		TypeMeta: metav1.TypeMeta{Kind: "CertificateSigningRequest", APIVersion: "certificates.k8s.io/v1beta1"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: config.CSRName,
-			Labels: map[string]string{
-				"k8s-app": config.AppName,
-			}},
-		Spec: certV1beta1.CertificateSigningRequestSpec{
-			Request:    x509CSR.CSR,
-			SignerName: &config.Signer,
-			Usages:     []certV1beta1.KeyUsage{certV1beta1.UsageServerAuth, certV1beta1.UsageClientAuth, certV1beta1.UsageDigitalSignature, certV1beta1.UsageKeyAgreement},
-		},
-	}
-
-	created, err := cli.Create(ctx, csr, metav1.CreateOptions{})
-	if err != nil {
-		if errors.IsAlreadyExists(err) {
-			// If this is the case, it means this pod crashed previously. We need to delete the CSR and re-submit a new CSR,
-			// otherwise we end up with a private key that does not match the issued cert.
-			if err = cli.Delete(ctx, config.CSRName, metav1.DeleteOptions{}); err != nil {
-				return err
-			}
-			if created, err = cli.Create(ctx, csr, metav1.CreateOptions{}); err != nil {
-				return err
-			}
-		} else {
-			return fmt.Errorf("crashed while trying to create Kubernetes certificate signing request: %w", err)
-		}
-	}
-
-	log.Infof("created CSR: %v", created)
-	return nil
-}
-
-func GetKubernetesVersion(clientset kubernetes.Interface) (*versionInfo, error) {
-	v, err := clientset.Discovery().ServerVersion()
-	if err != nil {
-		return nil, fmt.Errorf("failed to check k8s version: %v", err)
-	}
-
-	major, err := strconv.Atoi(v.Major)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse k8s major version: %s", v.Major)
-	}
-
-	// filter out a proceeding '+' from the minor version since openshift includes that.
-	minor, err := strconv.Atoi(strings.TrimSuffix(v.Minor, "+"))
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse k8s minor version: %s", v.Minor)
-	}
-
-	return &versionInfo{
-		Major: major,
-		Minor: minor,
-	}, nil
 }

--- a/pkg/k8s/certificate.go
+++ b/pkg/k8s/certificate.go
@@ -103,6 +103,8 @@ func SubmitCSR(ctx context.Context, config *cfg.Config, restClient *RestClient, 
 			Name: config.CSRName,
 			Labels: map[string]string{
 				"k8s-app": config.AppName,
+				// Add a label so that our controller can filter on CSRs issued by tigera.
+				"operator.tigera.io/csr": config.AppName,
 			}},
 		Spec: certV1.CertificateSigningRequestSpec{
 			Request:    x509CSR.CSR,

--- a/pkg/k8s/certificate_test.go
+++ b/pkg/k8s/certificate_test.go
@@ -16,10 +16,8 @@ package k8s_test
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -30,8 +28,6 @@ import (
 	certV1 "k8s.io/api/certificates/v1"
 	certV1beta1 "k8s.io/api/certificates/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/version"
-	discoveryFake "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -65,10 +61,6 @@ var _ = Describe("Test Certificates", func() {
 	Context("Test submitting a CSR", func() {
 		It("should list no CSRs when the suite starts", func() {
 			By("create a k8s client with high version")
-			clientset.Discovery().(*discoveryFake.FakeDiscovery).FakedServerVersion = &version.Info{
-				Major: strconv.Itoa(3),
-				Minor: strconv.Itoa(2),
-			}
 			restClient = &k8s.RestClient{
 				APIRegistrationClient: nil,
 				Clientset:             clientset,
@@ -97,89 +89,6 @@ var _ = Describe("Test Certificates", func() {
 			Expect(csr.Spec.Usages).NotTo(ConsistOf(certV1beta1.UsageServerAuth, certV1beta1.UsageClientAuth,
 				certV1beta1.UsageDigitalSignature, certV1beta1.UsageKeyAgreement))
 		})
-
-		It("should list no CSRs when the suite starts", func() {
-			By("create a k8s client with lower version")
-			clientset.Discovery().(*discoveryFake.FakeDiscovery).FakedServerVersion = &version.Info{
-				Major: strconv.Itoa(1),
-				Minor: strconv.Itoa(18),
-			}
-			restClient = &k8s.RestClient{
-				APIRegistrationClient: nil,
-				Clientset:             clientset,
-				RestConfig:            nil,
-			}
-
-			By("verifying no v1beta1 CSRs are present yet")
-			resp, err := clientset.CertificatesV1beta1().CertificateSigningRequests().List(ctx, v1.ListOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(resp.Items).To(HaveLen(0))
-
-			By("creating the v1beta1 CSRs are present yet")
-			Expect(k8s.SubmitCSR(ctx, config, restClient, tlsCsr)).ToNot(HaveOccurred())
-
-			By("Verifying the object exists with the right settings")
-			csrs, err := clientset.CertificatesV1beta1().CertificateSigningRequests().List(ctx, v1.ListOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(csrs.Items).To(HaveLen(1))
-			csr := csrs.Items[0]
-
-			Expect(csr.Name).To(Equal(csrName))
-			Expect(csr.Spec.Request).To(Equal(csrPem))
-			Expect(*csr.Spec.SignerName).To(Equal(signer))
-			Expect(csr.Spec.Usages).To(ConsistOf(certV1beta1.UsageServerAuth, certV1beta1.UsageClientAuth,
-				certV1beta1.UsageDigitalSignature, certV1beta1.UsageKeyAgreement))
-			Expect(csr.Spec.Usages).NotTo(ConsistOf(certV1.UsageServerAuth, certV1.UsageClientAuth,
-				certV1.UsageDigitalSignature, certV1.UsageKeyAgreement))
-		})
-	})
-})
-
-var _ = Describe("Test get Kubernetes version", func() {
-	var clientset kubernetes.Interface
-
-	BeforeEach(func() {
-		clientset = fake.NewSimpleClientset()
-	})
-
-	It("should return expected major and minor version when both version numbers are valid integers", func() {
-		expectedMajor := 3
-		expectedMinor := 22
-		clientset.Discovery().(*discoveryFake.FakeDiscovery).FakedServerVersion = &version.Info{
-			Major: strconv.Itoa(expectedMajor),
-			Minor: strconv.Itoa(expectedMinor),
-		}
-
-		version, err := k8s.GetKubernetesVersion(clientset)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(version.Major).To(Equal(expectedMajor))
-		Expect(version.Minor).To(Equal(expectedMinor))
-	})
-
-	It("should return error when major version is invalid", func() {
-		invalidMajor := "invalid_major_version"
-		clientset.Discovery().(*discoveryFake.FakeDiscovery).FakedServerVersion = &version.Info{
-			Major: invalidMajor,
-			Minor: "19",
-		}
-
-		v, err := k8s.GetKubernetesVersion(clientset)
-		Expect(v).To(BeNil())
-		Expect(err).To(HaveOccurred())
-		Expect(err).To(Equal(fmt.Errorf("failed to parse k8s major version: %s", invalidMajor)))
-	})
-
-	It("should return error when minor version is invalid", func() {
-		invalidMinor := "invalid_minor_version"
-		clientset.Discovery().(*discoveryFake.FakeDiscovery).FakedServerVersion = &version.Info{
-			Major: "1",
-			Minor: invalidMinor,
-		}
-
-		v, err := k8s.GetKubernetesVersion(clientset)
-		Expect(v).To(BeNil())
-		Expect(err).To(HaveOccurred())
-		Expect(err).To(Equal(fmt.Errorf("failed to parse k8s minor version: %s", invalidMinor)))
 	})
 })
 


### PR DESCRIPTION
Three improvements I found while working with CSRs:
- Add a configurable timeout to the csr container. Once expired, it will crash-loop, making the pod re-issue a CSR.
- Remove v1beta1 related code, this API has been removed from k8s
- Allow setting a name prefix. This can avoid duplication of CSR name if the same pod submits more than one CSR
- Fix CI / update go-build to v0.89
- Add label to help operator filter tigera CSRs in watches and reconcile loops.

The changes should be backwards compatible.